### PR TITLE
[feat] 키보드 올라올때 뷰 같이 올라오게 설정, 채팅창 들어갔을때 제일 밑 대화 보이기

### DIFF
--- a/PuppyTing/View/Chat/ChatListViewController.swift
+++ b/PuppyTing/View/Chat/ChatListViewController.swift
@@ -27,6 +27,7 @@ class ChatListViewController: UIViewController, UITableViewDelegate, UISearchBar
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
         setupUI()
         bindTableView()
         


### PR DESCRIPTION
## 📝 개요

채팅방 들어갔을 때 제일 마지막 대화 보이게 하고, 키보드 올라갈 때 채팅방 뷰 같이 올라가도록 설정

## 📌 관련 이슈

연관된 이슈 번호를 언급해주세요:
- 관련 이슈: #이슈번호

## 🔍 변경 사항

다음과 같은 변경 사항이 있습니다:
- [ ] 채팅방 들어갔을 때 제일 위 대화 말고 제일 밑 대화 보이게 변경
- [ ] 키보드 올라갈 때 뷰 함께 올라가도록
- [ ] pr때 요청 받은 간단한 코드 리팩토링

## 📷 스크린샷 (선택사항)

![Simulator Screen Recording - iPhone 15 Pro - 2024-09-02 at 10 28 53](https://github.com/user-attachments/assets/937e2961-79b8-48c2-9c87-47ac5f57001e)


## ✅ 체크리스트

- [x] 코드가 프로젝트의 스타일 가이드를 준수합니다.
- [x] PR 제목이 명확하고 간결하게 작성되었습니다.
- [ ] 관련 문서가 업데이트되었습니다.
- [ ] 로컬 환경에서 모든 테스트가 통과되었습니다.
- [x] 필요한 경우 리뷰어들이 이해하기 쉽게 주석을 추가했습니다.

## 🔗 참고 자료

PR에 참고해야 할 자료나 링크가 있다면 추가해주세요.

## ⚠️ 주의 사항

기존 코드에 코드 추가를 하다보니 두서가 없을 수 있습니다. 수정 필요한 부분 알려주세면 수정하겠습니다~!
