### PR TITLE
[fix] 초기 채팅방에서 빈 문자열상태로 send버튼 클릭시 오류해결

### DIFF
--- a/PuppyTing/View/Chat/ChatViewController.swift
+++ b/PuppyTing/View/Chat/ChatViewController.swift
@@ -140,6 +140,7 @@ class ChatViewController: UIViewController {
         // sendButton 클릭 시 ViewModel에 메세지 전달
         sendButton.rx.tap
             .withLatestFrom(messageTextView.rx.text.orEmpty) // 버튼 눌렸을 때 텍스트뷰 내용 가져옴
+            .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty } // 빈 문자열 필터링
             .bind(to: viewModel.messageText) // ViewModel의 MessageText에 바인딩
             .disposed(by: disposeBag)
         


### PR DESCRIPTION
## 📝 개요

채팅방에서 빈텍스트뷰 send버튼 클릭시 레이아웃 설정 오류

## 📌 관련 이슈

연관된 이슈 번호를 언급해주세요:
- 관련 이슈: #이슈번호

## 🔍 변경 사항

다음과 같은 변경 사항이 있습니다:
- [x] sendButton tap 할 때 빈문자열 필터링 코드 추가

## 📷 스크린샷 (선택사항)

변경 사항이 UI에 영향을 미치는 경우, 이전과 이후의 스크린샷을 포함해 주세요.

## ✅ 체크리스트

- [ ] 코드가 프로젝트의 스타일 가이드를 준수합니다.
- [ ] PR 제목이 명확하고 간결하게 작성되었습니다.
- [ ] 관련 문서가 업데이트되었습니다.
- [ ] 로컬 환경에서 모든 테스트가 통과되었습니다.
- [x] 필요한 경우 리뷰어들이 이해하기 쉽게 주석을 추가했습니다.

## 🔗 참고 자료

PR에 참고해야 할 자료나 링크가 있다면 추가해주세요.

## ⚠️ 주의 사항

리뷰어가 중점적으로 봐야 할 사항이나, 이 PR에 포함되지 않은 추가적인 설명이 필요하다면 여기에 작성해주세요.
