### PR TITLE
[feat] 다른 유저 프로필 화면(ProfileVC, ProfileCell, PuppyHeaderCell) 생성

### DIFF
--- a/PuppyTing.xcodeproj/project.pbxproj
+++ b/PuppyTing.xcodeproj/project.pbxproj
@@ -8,7 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		23607BFA2C8978E600A23716 /* PostingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23607BF92C8978E600A23716 /* PostingViewModel.swift */; };
-		236E023F2C892B0200469FE0 /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 236E023E2C892B0200469FE0 /* Config.xcconfig */; };
+		5602B05C2C8A828A0060F03B /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 5602B05B2C8A828A0060F03B /* Config.xcconfig */; };
+		5602B05E2C8A82E50060F03B /* ProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5602B05D2C8A82E50060F03B /* ProfileViewController.swift */; };
+		5602B0692C8AEA340060F03B /* ProfileCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5602B0682C8AEA340060F03B /* ProfileCell.swift */; };
+		5602B0712C8AF4EF0060F03B /* PuppyHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5602B0702C8AF4EF0060F03B /* PuppyHeaderCell.swift */; };
 		56D686C52C7DA88500B00880 /* SignupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D686C42C7DA88500B00880 /* SignupViewController.swift */; };
 		56D686C82C7DB09600B00880 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D686C72C7DB09600B00880 /* LoginViewController.swift */; };
 		56D686CC2C7DC88700B00880 /* PptLoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D686CB2C7DC88600B00880 /* PptLoginViewController.swift */; };
@@ -72,7 +75,10 @@
 
 /* Begin PBXFileReference section */
 		23607BF92C8978E600A23716 /* PostingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingViewModel.swift; sourceTree = "<group>"; };
-		236E023E2C892B0200469FE0 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Config.xcconfig; path = ../../../../../Downloads/Config.xcconfig; sourceTree = "<group>"; };
+		5602B05B2C8A828A0060F03B /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
+		5602B05D2C8A82E50060F03B /* ProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
+		5602B0682C8AEA340060F03B /* ProfileCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileCell.swift; sourceTree = "<group>"; };
+		5602B0702C8AF4EF0060F03B /* PuppyHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PuppyHeaderCell.swift; sourceTree = "<group>"; };
 		56D686C42C7DA88500B00880 /* SignupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupViewController.swift; sourceTree = "<group>"; };
 		56D686C72C7DB09600B00880 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		56D686CB2C7DC88600B00880 /* PptLoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PptLoginViewController.swift; sourceTree = "<group>"; };
@@ -148,6 +154,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		5602B05F2C8A82F10060F03B /* Profile */ = {
+			isa = PBXGroup;
+			children = (
+				5602B05D2C8A82E50060F03B /* ProfileViewController.swift */,
+				5602B0682C8AEA340060F03B /* ProfileCell.swift */,
+				5602B0702C8AF4EF0060F03B /* PuppyHeaderCell.swift */,
+			);
+			path = Profile;
+			sourceTree = "<group>";
+		};
 		56D686C32C7DA81700B00880 /* Signup */ = {
 			isa = PBXGroup;
 			children = (
@@ -265,6 +281,7 @@
 				E738FB982C7C651D004696BD /* Ting */,
 				E738FB972C7C6518004696BD /* Chat */,
 				E738FB962C7C6510004696BD /* Mypage */,
+				5602B05F2C8A82F10060F03B /* Profile */,
 				A2F9FE4C2C896EE0004D7FF6 /* AppController.swift */,
 			);
 			path = View;
@@ -299,7 +316,7 @@
 			children = (
 				E738FB762C7C62EE004696BD /* AppDelegate.swift */,
 				E738FB782C7C62EE004696BD /* SceneDelegate.swift */,
-				236E023E2C892B0200469FE0 /* Config.xcconfig */,
+				5602B05B2C8A828A0060F03B /* Config.xcconfig */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -438,9 +455,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				E738FB802C7C62F0004696BD /* Assets.xcassets in Resources */,
+				5602B05C2C8A828A0060F03B /* Config.xcconfig in Resources */,
 				A2085DD82C806F8D00698923 /* GoogleService-Info.plist in Resources */,
 				E738FBAA2C7C6BB3004696BD /* .gitignore in Resources */,
-				236E023F2C892B0200469FE0 /* Config.xcconfig in Resources */,
 				E738FB832C7C62F0004696BD /* Base in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -460,9 +477,11 @@
 				A2085DD42C80622B00698923 /* PptLoginViewModel.swift in Sources */,
 				56D686C82C7DB09600B00880 /* LoginViewController.swift in Sources */,
 				C29FCFC32C88610600F8951D /* MyFeedTableViCell.swift in Sources */,
+				5602B05E2C8A82E50060F03B /* ProfileViewController.swift in Sources */,
 				E738FB9A2C7C6532004696BD /* TingViewController.swift in Sources */,
 				56FD048F2C80171100EBCDCD /* MyChattingTableViewCell.swift in Sources */,
 				23607BFA2C8978E600A23716 /* PostingViewModel.swift in Sources */,
+				5602B0712C8AF4EF0060F03B /* PuppyHeaderCell.swift in Sources */,
 				C29FCF662C7DB37E00F8951D /* PuppyCollectionViewCell.swift in Sources */,
 				E7F5983B2C8866CE00FE8900 /* AddressView.swift in Sources */,
 				A2085DD12C8059F400698923 /* FireStoreDatabaseManager.swift in Sources */,
@@ -496,6 +515,7 @@
 				56D686CC2C7DC88700B00880 /* PptLoginViewController.swift in Sources */,
 				A2F9FE4D2C896EE0004D7FF6 /* AppController.swift in Sources */,
 				E738FB792C7C62EE004696BD /* SceneDelegate.swift in Sources */,
+				5602B0692C8AEA340060F03B /* ProfileCell.swift in Sources */,
 				E70DB34D2C8067B50073B3F8 /* SearchAddressViewController.swift in Sources */,
 				A2085DCF2C804C7300698923 /* FirebaseAuthManager.swift in Sources */,
 			);
@@ -517,7 +537,6 @@
 /* Begin XCBuildConfiguration section */
 		E738FB852C7C62F0004696BD /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 236E023E2C892B0200469FE0 /* Config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -581,7 +600,6 @@
 		};
 		E738FB862C7C62F0004696BD /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 236E023E2C892B0200469FE0 /* Config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;

--- a/PuppyTing/View/Profile/ProfileCell.swift
+++ b/PuppyTing/View/Profile/ProfileCell.swift
@@ -1,0 +1,184 @@
+//
+//  ProfileCell.swift
+//  PuppyTing
+//
+//  Created by 내꺼다 on 9/6/24.
+//
+
+import UIKit
+
+import SnapKit
+
+class ProfileCell: UICollectionViewCell {
+    
+    private let stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.spacing = 10
+        stackView.distribution = .fill
+        return stackView
+    }()
+    
+    private let profileContainerView: UIView = {
+        let view = UIView()
+        view.layer.cornerRadius = 15
+        view.layer.borderWidth = 1.0
+        view.layer.borderColor = UIColor.puppyPurple.withAlphaComponent(0.1).cgColor
+        view.layer.masksToBounds = true
+        view.backgroundColor = UIColor.puppyPurple.withAlphaComponent(0.1)
+        return view
+    }()
+    
+    private let profileImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
+        imageView.tintColor = .black
+        imageView.image = UIImage(systemName: "person.crop.circle")
+        return imageView
+    }()
+    
+    private let nicknameLabel: UILabel = {
+        let label = UILabel()
+        label.text = "닉네임"
+        label.font = UIFont.boldSystemFont(ofSize: 16)
+        return label
+    }()
+    
+    private let footView = UIView()
+    
+    private let footStampLabel: UILabel = {
+        let label = UILabel()
+        label.text = "🐾 받은 발도장"
+        return label
+    }()
+    
+    private let footNumberLabel: UILabel = {
+        let label = UILabel()
+        label.text = "nn개"
+        return label
+    }()
+    
+    private let evaluateView = UIView()
+    
+    private let footButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("발도장 꾹 🐾", for: .normal)
+        button.backgroundColor = UIColor.puppyPurple
+        button.layer.cornerRadius = 10
+        button.setTitleColor(.white, for: .normal)
+        button.addTarget(self, action: #selector(footButtonTapped), for: .touchUpInside)
+        return button
+    }()
+    
+    private let blockButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("차단하기", for: .normal)
+        button.backgroundColor = UIColor.puppyPurple
+        button.layer.cornerRadius = 10
+        button.setTitleColor(.white, for: .normal)
+        return button
+    }()
+    
+    private let favoriteButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("즐겨찾기", for: .normal)
+        button.backgroundColor = UIColor.puppyPurple
+        button.layer.cornerRadius = 10
+        button.setTitleColor(.white, for: .normal)
+        return button
+    }()
+    
+    // 작동되는지 확인
+    @objc private func footButtonTapped() {
+        print("발도장 남기기 버튼 눌림")
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        contentView.addSubview(stackView)
+        stackView.addArrangedSubview(profileContainerView)
+        
+        [profileImageView, nicknameLabel, footView, evaluateView].forEach {
+            profileContainerView.addSubview($0)
+        }
+        
+        [footStampLabel, footNumberLabel].forEach {
+            footView.addSubview($0)
+        }
+        
+        [footButton, favoriteButton, blockButton].forEach {
+            evaluateView.addSubview($0)
+        }
+        
+        stackView.snp.makeConstraints {
+            $0.edges.equalToSuperview().inset(20)
+        }
+        
+        profileContainerView.snp.makeConstraints {
+            $0.width.equalToSuperview()
+            $0.top.equalTo(stackView.snp.top)
+        }
+        
+        profileImageView.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(10)
+            $0.left.equalToSuperview().offset(10)
+            $0.width.height.equalTo(60)
+        }
+        
+        nicknameLabel.snp.makeConstraints {
+            $0.left.equalTo(profileImageView.snp.right).offset(10)
+            $0.centerY.equalTo(profileImageView.snp.centerY)
+        }
+        
+        footView.snp.makeConstraints {
+            $0.top.equalTo(profileImageView.snp.bottom).offset(20)
+            $0.centerX.equalToSuperview()
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(40)
+        }
+        
+        footStampLabel.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.leading.equalToSuperview().offset(10)
+        }
+        
+        footNumberLabel.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.leading.equalTo(footStampLabel.snp.trailing).offset(20)
+        }
+        
+        evaluateView.snp.makeConstraints {
+            $0.top.equalTo(footView.snp.bottom).offset(10)
+            $0.centerX.equalToSuperview()
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(44)
+        }
+        
+        footButton.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.trailing.equalTo(favoriteButton.snp.leading).offset(-5)
+            $0.height.equalTo(44)
+            $0.width.equalTo(110)
+        }
+        
+        favoriteButton.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.centerX.equalToSuperview()
+            $0.height.equalTo(44)
+            $0.width.equalTo(110)
+        }
+        
+        blockButton.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.leading.equalTo(favoriteButton.snp.trailing).offset(5)
+            $0.height.equalTo(44)
+            $0.width.equalTo(110)
+        }
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/PuppyTing/View/Profile/ProfileViewController.swift
+++ b/PuppyTing/View/Profile/ProfileViewController.swift
@@ -1,0 +1,96 @@
+//
+//  ProfileViewController.swift
+//  PuppyTing
+//
+//  Created by 내꺼다 on 9/6/24.
+//
+
+import UIKit
+
+import SnapKit
+
+class ProfileViewController: UIViewController {
+    
+    private let closeButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("✕", for: .normal)
+        button.titleLabel?.font = .systemFont(ofSize: 20)
+        button.setTitleColor(.black, for: .normal)
+        button.addTarget(ProfileViewController.self, action: #selector(didTapCloseButton), for: .touchUpInside)
+        return button
+    }()
+    
+    private let collectionView: UICollectionView = {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .vertical
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        collectionView.backgroundColor = .white
+        collectionView.showsVerticalScrollIndicator = false
+        return collectionView
+    }()
+    
+    @objc
+    private func didTapCloseButton() {
+        dismiss(animated: true)
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        view.backgroundColor = .white
+        collectionView.dataSource = self
+        collectionView.delegate = self
+        
+        // 버튼을 먼저 추가
+        view.addSubview(closeButton)
+        closeButton.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(10)
+            $0.leading.equalTo(view.safeAreaLayoutGuide).offset(10)
+            $0.height.width.equalTo(44)
+        }
+        
+        // 이후에 collectionView 추가
+        view.addSubview(collectionView)
+        collectionView.snp.makeConstraints {
+            $0.top.equalTo(closeButton.snp.bottom).offset(10)
+            $0.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide)
+        }
+        
+        collectionView.register(ProfileCell.self, forCellWithReuseIdentifier: "ProfileCell")
+        collectionView.register(PuppyHeaderCell.self, forCellWithReuseIdentifier: "PuppyHeaderCell")
+    }
+}
+
+extension ProfileViewController: UICollectionViewDataSource {
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return 2
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        switch indexPath.item {
+        case 0:
+            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "ProfileCell", for: indexPath) as! ProfileCell
+            return cell
+        case 1:
+            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "PuppyHeaderCell", for: indexPath) as! PuppyHeaderCell
+            return cell
+        default:
+            fatalError("Unexpected index path")
+        }
+    }
+}
+
+extension ProfileViewController: UICollectionViewDelegateFlowLayout {
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        switch indexPath.item {
+        case 0:
+            return CGSize(width: collectionView.bounds.width, height: 250) // ProfileCell size
+        case 1:
+            return CGSize(width: collectionView.bounds.width, height: 40) // PuppyHeaderCell size
+        default:
+            return CGSize(width: collectionView.bounds.width, height: 100)
+        }
+    }
+}

--- a/PuppyTing/View/Profile/PuppyHeaderCell.swift
+++ b/PuppyTing/View/Profile/PuppyHeaderCell.swift
@@ -1,0 +1,37 @@
+//
+//  PuppyHeaderCell.swift
+//  PuppyTing
+//
+//  Created by 내꺼다 on 9/6/24.
+//
+
+import UIKit
+
+import SnapKit
+
+class PuppyHeaderCell: UICollectionViewCell {
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "퍼피 목록"
+        label.font = UIFont.boldSystemFont(ofSize: 18)
+        label.textColor = .black
+        return label
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupUI() {
+        contentView.addSubview(titleLabel)
+        titleLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().offset(20)
+        }
+    }
+}


### PR DESCRIPTION
## 📝 개요

다른 유저의 프로필확인하는 화면

## 📌 관련 이슈

연관된 이슈 번호를 언급해주세요:
- 관련 이슈: #이슈번호

## 🔍 변경 사항

다음과 같은 변경 사항이 있습니다:
- [x] ProfileVC 생성
- [x] ProfileCell생성
- [x] PuppyHeaderCell 생성

## 📷 스크린샷 (선택사항)
<img width="402" alt="스크린샷 2024-09-06 오후 6 06 25" src="https://github.com/user-attachments/assets/cda5d262-cf0d-40be-8996-2b1ed5ecab7e">

## ✅ 체크리스트

- [x] 코드가 프로젝트의 스타일 가이드를 준수합니다.
- [ ] PR 제목이 명확하고 간결하게 작성되었습니다.
- [ ] 관련 문서가 업데이트되었습니다.
- [ ] 로컬 환경에서 모든 테스트가 통과되었습니다.
- [ ] 필요한 경우 리뷰어들이 이해하기 쉽게 주석을 추가했습니다.

## 🔗 참고 자료

PR에 참고해야 할 자료나 링크가 있다면 추가해주세요.

## ⚠️ 주의 사항

퍼피목록 밑에는 내정보 저장했던것처럼 강아지 정보 나오는 셀 추가 예정인데
그부분은 아직 어떻게 저장할지 논의를 해봐야해서 만들어놓지는 않았습니다.
ui 변경 가능성 많습니다.
