### PR TITLE
[feat] 상대이미지&닉네임 클릭시 프로필 화면 띄워주기

### DIFF
--- a/PuppyTing.xcodeproj/project.pbxproj
+++ b/PuppyTing.xcodeproj/project.pbxproj
@@ -8,10 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		23607BFA2C8978E600A23716 /* PostingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23607BF92C8978E600A23716 /* PostingViewModel.swift */; };
-		23607C042C8B023F00A23716 /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 23607C032C8B023F00A23716 /* Config.xcconfig */; };
 		5602B05E2C8A82E50060F03B /* ProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5602B05D2C8A82E50060F03B /* ProfileViewController.swift */; };
 		5602B0692C8AEA340060F03B /* ProfileCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5602B0682C8AEA340060F03B /* ProfileCell.swift */; };
 		5602B0712C8AF4EF0060F03B /* PuppyHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5602B0702C8AF4EF0060F03B /* PuppyHeaderCell.swift */; };
+		5602B0752C8C62C30060F03B /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 5602B0742C8C62C30060F03B /* Config.xcconfig */; };
 		56D686C52C7DA88500B00880 /* SignupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D686C42C7DA88500B00880 /* SignupViewController.swift */; };
 		56D686C82C7DB09600B00880 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D686C72C7DB09600B00880 /* LoginViewController.swift */; };
 		56D686CC2C7DC88700B00880 /* PptLoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D686CB2C7DC88600B00880 /* PptLoginViewController.swift */; };
@@ -75,10 +75,10 @@
 
 /* Begin PBXFileReference section */
 		23607BF92C8978E600A23716 /* PostingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingViewModel.swift; sourceTree = "<group>"; };
-		23607C032C8B023F00A23716 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Config.xcconfig; path = ../../../../../Downloads/Config.xcconfig; sourceTree = "<group>"; };
 		5602B05D2C8A82E50060F03B /* ProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
 		5602B0682C8AEA340060F03B /* ProfileCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileCell.swift; sourceTree = "<group>"; };
 		5602B0702C8AF4EF0060F03B /* PuppyHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PuppyHeaderCell.swift; sourceTree = "<group>"; };
+		5602B0742C8C62C30060F03B /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		56D686C42C7DA88500B00880 /* SignupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupViewController.swift; sourceTree = "<group>"; };
 		56D686C72C7DB09600B00880 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		56D686CB2C7DC88600B00880 /* PptLoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PptLoginViewController.swift; sourceTree = "<group>"; };
@@ -316,7 +316,7 @@
 			children = (
 				E738FB762C7C62EE004696BD /* AppDelegate.swift */,
 				E738FB782C7C62EE004696BD /* SceneDelegate.swift */,
-				23607C032C8B023F00A23716 /* Config.xcconfig */,
+				5602B0742C8C62C30060F03B /* Config.xcconfig */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -455,7 +455,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E738FB802C7C62F0004696BD /* Assets.xcassets in Resources */,
-				23607C042C8B023F00A23716 /* Config.xcconfig in Resources */,
+				5602B0752C8C62C30060F03B /* Config.xcconfig in Resources */,
 				A2085DD82C806F8D00698923 /* GoogleService-Info.plist in Resources */,
 				E738FBAA2C7C6BB3004696BD /* .gitignore in Resources */,
 				E738FB832C7C62F0004696BD /* Base in Resources */,
@@ -537,7 +537,6 @@
 /* Begin XCBuildConfiguration section */
 		E738FB852C7C62F0004696BD /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 23607C032C8B023F00A23716 /* Config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -601,7 +600,6 @@
 		};
 		E738FB862C7C62F0004696BD /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 23607C032C8B023F00A23716 /* Config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;

--- a/PuppyTing/View/Profile/ProfileCell.swift
+++ b/PuppyTing/View/Profile/ProfileCell.swift
@@ -34,7 +34,7 @@ class ProfileCell: UICollectionViewCell {
         imageView.contentMode = .scaleAspectFill
         imageView.clipsToBounds = true
         imageView.tintColor = .black
-        imageView.image = UIImage(systemName: "person.crop.circle")
+        imageView.image = UIImage(named: "defaultProfileImage")
         return imageView
     }()
     

--- a/PuppyTing/View/Profile/ProfileViewController.swift
+++ b/PuppyTing/View/Profile/ProfileViewController.swift
@@ -11,14 +11,15 @@ import SnapKit
 
 class ProfileViewController: UIViewController {
     
-    private let closeButton: UIButton = {
-        let button = UIButton(type: .system)
-        button.setTitle("✕", for: .normal)
-        button.titleLabel?.font = .systemFont(ofSize: 20)
-        button.setTitleColor(.black, for: .normal)
-        button.addTarget(ProfileViewController.self, action: #selector(didTapCloseButton), for: .touchUpInside)
-        return button
-    }()
+//    하프모달 시 클로즈버튼 필요 없음
+//    private let closeButton: UIButton = {
+//        let button = UIButton(type: .system)
+//        button.setTitle("✕", for: .normal)
+//        button.titleLabel?.font = .systemFont(ofSize: 20)
+//        button.setTitleColor(.black, for: .normal)
+//        button.addTarget(self, action: #selector(didTapCloseButton), for: .touchUpInside)
+//        return button
+//    }()
     
     private let collectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
@@ -41,18 +42,18 @@ class ProfileViewController: UIViewController {
         collectionView.dataSource = self
         collectionView.delegate = self
         
-        // 버튼을 먼저 추가
-        view.addSubview(closeButton)
-        closeButton.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide).offset(10)
-            $0.leading.equalTo(view.safeAreaLayoutGuide).offset(10)
-            $0.height.width.equalTo(44)
-        }
+        // 버튼을 먼저 추가 - 클로즈버튼 하프모달시 필요없음
+//        view.addSubview(closeButton)
+//        closeButton.snp.makeConstraints {
+//            $0.top.equalTo(view.safeAreaLayoutGuide).offset(10)
+//            $0.leading.equalTo(view.safeAreaLayoutGuide).offset(10)
+//            $0.height.width.equalTo(44)
+//        }
         
-        // 이후에 collectionView 추가
         view.addSubview(collectionView)
         collectionView.snp.makeConstraints {
-            $0.top.equalTo(closeButton.snp.bottom).offset(10)
+//            $0.top.equalTo(closeButton.snp.bottom).offset(10)
+            $0.top.equalTo(view.safeAreaLayoutGuide)
             $0.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide)
         }
         

--- a/PuppyTing/View/Ting/DetailTingViewController.swift
+++ b/PuppyTing/View/Ting/DetailTingViewController.swift
@@ -150,6 +150,27 @@ class DetailTingViewController: UIViewController {
         setConstraints()
         setData()
         bind()
+        
+        // profilePic에 탭 추가 -> ProfileViewController 연결
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(didTapProfile))
+        profilePic.isUserInteractionEnabled = true
+        profilePic.addGestureRecognizer(tapGesture)
+        // 닉네임에도 탭 추가
+        let nameTapGesture = UITapGestureRecognizer(target: self, action: #selector(didTapProfile))
+        nameLabel.isUserInteractionEnabled = true
+        nameLabel.addGestureRecognizer(nameTapGesture)
+    }
+    
+    @objc private func didTapProfile() {
+        let profileVC = ProfileViewController()
+        
+        // 하프모달로 띄우기
+        if let sheet = profileVC.sheetPresentationController {
+            sheet.detents = [.medium()] // 모달크기 설정
+            sheet.prefersGrabberVisible = true // 위에 바 나오게 하기
+        }
+        
+        present(profileVC, animated: true)
     }
     
     //MARK: bind


### PR DESCRIPTION
## 📝 개요

변경 사항에 대한 간단한 설명을 작성해주세요.
이 PR이 무엇을 다루고 있는지, 어떤 문제를 해결하는지 또는 어떤 기능을 추가하는지 간략하게 설명합니다.

## 📌 관련 이슈

연관된 이슈 번호를 언급해주세요:
- 관련 이슈: #이슈번호

## 🔍 변경 사항

다음과 같은 변경 사항이 있습니다:
- [x] 게시글에서 이미지, 닉네임 클릭 시 프로필뷰 화면 띄우기

- [x] 프로필뷰 하프모달시 클로즈버튼 삭제


## 📷 스크린샷 (선택사항)

<img width="410" alt="스크린샷 2024-09-07 오후 7 43 10" src="https://github.com/user-attachments/assets/e316ba15-1b01-4084-93b8-590019d5528b">

## ✅ 체크리스트

- [x] 코드가 프로젝트의 스타일 가이드를 준수합니다.
- [x] PR 제목이 명확하고 간결하게 작성되었습니다.
- [ ] 관련 문서가 업데이트되었습니다.
- [ ] 로컬 환경에서 모든 테스트가 통과되었습니다.
- [x] 필요한 경우 리뷰어들이 이해하기 쉽게 주석을 추가했습니다.

## 🔗 참고 자료

PR에 참고해야 할 자료나 링크가 있다면 추가해주세요.

## ⚠️ 주의 사항

하프모달변경 의견으로 하프모달로 연결해줬고 하프모달시 x버튼 불필요해서 주석처리로 일단 남겨놨습니다.
프로필 퍼피목록은 프로필브랜치에서 화면 전체수정시 수정하려고 일단 뒀습니다.
탭제스처 일단 그냥 작성했는데 rx로 코드 맞추기 원하시면 수정하겠습니다.
이미지랑 닉네임 전체 묶어서 뷰로 탭제스처 추가하려고했는데 코드 수정이 필요해서 일단 이미지 따로 닉네임 따로 탭제스처 연결해놨습니다.
수정사항 요청시 수정하겠습니다.
