### PR TITLE
[feat] 채팅방에서 프로필사진 클릭시 프로필정보 화면창 하프모달로띄우기

### DIFF
--- a/PuppyTing.xcodeproj/project.pbxproj
+++ b/PuppyTing.xcodeproj/project.pbxproj
@@ -9,10 +9,10 @@
 /* Begin PBXBuildFile section */
 		23607BFA2C8978E600A23716 /* PostingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23607BF92C8978E600A23716 /* PostingViewModel.swift */; };
 		23607C022C8A930100A23716 /* UIButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23607C012C8A930100A23716 /* UIButton.swift */; };
-		23607C0A2C8C6CBA00A23716 /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 23607C092C8C6CBA00A23716 /* Config.xcconfig */; };
 		5602B05E2C8A82E50060F03B /* ProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5602B05D2C8A82E50060F03B /* ProfileViewController.swift */; };
 		5602B0692C8AEA340060F03B /* ProfileCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5602B0682C8AEA340060F03B /* ProfileCell.swift */; };
 		5602B0712C8AF4EF0060F03B /* PuppyHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5602B0702C8AF4EF0060F03B /* PuppyHeaderCell.swift */; };
+		5602B07B2C8C7ED70060F03B /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 5602B07A2C8C7ED70060F03B /* Config.xcconfig */; };
 		56D686C52C7DA88500B00880 /* SignupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D686C42C7DA88500B00880 /* SignupViewController.swift */; };
 		56D686C82C7DB09600B00880 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D686C72C7DB09600B00880 /* LoginViewController.swift */; };
 		56D686CC2C7DC88700B00880 /* PptLoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D686CB2C7DC88600B00880 /* PptLoginViewController.swift */; };
@@ -83,10 +83,10 @@
 /* Begin PBXFileReference section */
 		23607BF92C8978E600A23716 /* PostingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingViewModel.swift; sourceTree = "<group>"; };
 		23607C012C8A930100A23716 /* UIButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIButton.swift; sourceTree = "<group>"; };
-		23607C092C8C6CBA00A23716 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Config.xcconfig; path = ../../../../../Downloads/Config.xcconfig; sourceTree = "<group>"; };
 		5602B05D2C8A82E50060F03B /* ProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewController.swift; sourceTree = "<group>"; };
 		5602B0682C8AEA340060F03B /* ProfileCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileCell.swift; sourceTree = "<group>"; };
 		5602B0702C8AF4EF0060F03B /* PuppyHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PuppyHeaderCell.swift; sourceTree = "<group>"; };
+		5602B07A2C8C7ED70060F03B /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		56D686C42C7DA88500B00880 /* SignupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupViewController.swift; sourceTree = "<group>"; };
 		56D686C72C7DB09600B00880 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		56D686CB2C7DC88600B00880 /* PptLoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PptLoginViewController.swift; sourceTree = "<group>"; };
@@ -314,8 +314,8 @@
 		E738FB912C7C6485004696BD /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				E738FB9F2C7C669D004696BD /* SampleModel.swift */,
 				E738FBC42C7DB85A004696BD /* TingFeedModel.swift */,
+				E738FB9F2C7C669D004696BD /* SampleModel.swift */,
 				A2085DC92C80395B00698923 /* Member.swift */,
 				E7F598332C847A7800FE8900 /* Place.swift */,
 				A2F9FE502C89D561004D7FF6 /* ChatModel.swift */,
@@ -344,7 +344,7 @@
 			children = (
 				E738FB762C7C62EE004696BD /* AppDelegate.swift */,
 				E738FB782C7C62EE004696BD /* SceneDelegate.swift */,
-				23607C092C8C6CBA00A23716 /* Config.xcconfig */,
+				5602B07A2C8C7ED70060F03B /* Config.xcconfig */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -484,9 +484,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				E738FB802C7C62F0004696BD /* Assets.xcassets in Resources */,
+				5602B07B2C8C7ED70060F03B /* Config.xcconfig in Resources */,
 				E738FBAA2C7C6BB3004696BD /* .gitignore in Resources */,
 				A2F9FE5B2C8C4D8C004D7FF6 /* GoogleService-Info.plist in Resources */,
-				23607C0A2C8C6CBA00A23716 /* Config.xcconfig in Resources */,
 				E738FB832C7C62F0004696BD /* Base in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -572,6 +572,7 @@
 /* Begin XCBuildConfiguration section */
 		E738FB852C7C62F0004696BD /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5602B07A2C8C7ED70060F03B /* Config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -635,6 +636,7 @@
 		};
 		E738FB862C7C62F0004696BD /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5602B07A2C8C7ED70060F03B /* Config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;

--- a/PuppyTing/View/Chat/ChatViewController.swift
+++ b/PuppyTing/View/Chat/ChatViewController.swift
@@ -169,6 +169,11 @@ class ChatViewController: UIViewController {
                     dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
                     let dateString = dateFormatter.string(from: date)
                     cell.date.text = dateString
+                    
+                    // 프로필 이미지 탭 클로저
+                    cell.profileImageTapped = { [weak self] in
+                        self?.presentProfileViewController()
+                    }
                     return cell
                 }
             }
@@ -186,6 +191,17 @@ class ChatViewController: UIViewController {
                 self?.scrollToBottom()
             })
             .disposed(by: disposeBag)
+    }
+    
+    // 하프모달로 띄우기
+    private func presentProfileViewController() {
+        let profileVC = ProfileViewController()
+        profileVC.modalPresentationStyle = .pageSheet
+        if let sheet = profileVC.sheetPresentationController {
+            sheet.detents = [.medium()]
+            sheet.prefersGrabberVisible = true
+        }
+        present(profileVC, animated: true, completion: nil)
     }
     
     // 제일 밑 채팅 보이기

--- a/PuppyTing/View/Chat/ChattingTableViewCell.swift
+++ b/PuppyTing/View/Chat/ChattingTableViewCell.swift
@@ -8,16 +8,17 @@
 import UIKit
 
 class ChattingTableViewCell: UITableViewCell {
-
+    
     static let identifier = "ChattingViewCell"
     
-   let profileImage: UIImageView = {
+    let profileImage: UIImageView = {
         let imageView = UIImageView()
         imageView.contentMode = .scaleAspectFill
         imageView.clipsToBounds = true
         imageView.layer.cornerRadius = 17
         imageView.layer.borderColor = UIColor.puppyPurple.cgColor
         imageView.layer.borderWidth = 1
+        imageView.isUserInteractionEnabled = true // 제스처 추가 위해 상호작용 가능하게
         return imageView
     }()
     
@@ -50,16 +51,26 @@ class ChattingTableViewCell: UITableViewCell {
         return label
     }()
     
+    var profileImageTapped: (() -> Void)? // 프로필 이미지 클릭 클로저
+    
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         
         selectionStyle = .none
         
         setupUI()
+        
+        // 프로필이미지 탭 제스처 추가
+        let chatImageTapGesture = UITapGestureRecognizer(target: self, action: #selector(profileTap))
+        profileImage.addGestureRecognizer(chatImageTapGesture)
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    @objc private func profileTap() {
+        profileImageTapped?() // 탭 클로저 호출
     }
     
     func setupUI() {

--- a/PuppyTing/View/Profile/ProfileViewController.swift
+++ b/PuppyTing/View/Profile/ProfileViewController.swift
@@ -11,16 +11,6 @@ import SnapKit
 
 class ProfileViewController: UIViewController {
     
-//    하프모달 시 클로즈버튼 필요 없음
-//    private let closeButton: UIButton = {
-//        let button = UIButton(type: .system)
-//        button.setTitle("✕", for: .normal)
-//        button.titleLabel?.font = .systemFont(ofSize: 20)
-//        button.setTitleColor(.black, for: .normal)
-//        button.addTarget(self, action: #selector(didTapCloseButton), for: .touchUpInside)
-//        return button
-//    }()
-    
     private let collectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .vertical
@@ -42,17 +32,8 @@ class ProfileViewController: UIViewController {
         collectionView.dataSource = self
         collectionView.delegate = self
         
-        // 버튼을 먼저 추가 - 클로즈버튼 하프모달시 필요없음
-//        view.addSubview(closeButton)
-//        closeButton.snp.makeConstraints {
-//            $0.top.equalTo(view.safeAreaLayoutGuide).offset(10)
-//            $0.leading.equalTo(view.safeAreaLayoutGuide).offset(10)
-//            $0.height.width.equalTo(44)
-//        }
-        
         view.addSubview(collectionView)
         collectionView.snp.makeConstraints {
-//            $0.top.equalTo(closeButton.snp.bottom).offset(10)
             $0.top.equalTo(view.safeAreaLayoutGuide)
             $0.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide)
         }

--- a/PuppyTing/View/Profile/ProfileViewController.swift
+++ b/PuppyTing/View/Profile/ProfileViewController.swift
@@ -20,11 +20,6 @@ class ProfileViewController: UIViewController {
         return collectionView
     }()
     
-    @objc
-    private func didTapCloseButton() {
-        dismiss(animated: true)
-    }
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         

--- a/PuppyTing/View/Ting/DetailTingViewController.swift
+++ b/PuppyTing/View/Ting/DetailTingViewController.swift
@@ -163,6 +163,7 @@ class DetailTingViewController: UIViewController {
     
     @objc private func didTapProfile() {
         let profileVC = ProfileViewController()
+        profileVC.modalPresentationStyle = .pageSheet
         
         // 하프모달로 띄우기
         if let sheet = profileVC.sheetPresentationController {


### PR DESCRIPTION
## 📝 개요

채팅방에서도 상대이미지 클릭 시 프로필정보화면 나오게 했습니다.

## 📌 관련 이슈

연관된 이슈 번호를 언급해주세요:
- 관련 이슈: #이슈번호

## 🔍 변경 사항

다음과 같은 변경 사항이 있습니다:
- [x] ChatViewController에 ProfileViewController 연결
- [x] 필요없는 주석 삭제


## 📷 스크린샷 (선택사항)

변경 사항이 UI에 영향을 미치는 경우, 이전과 이후의 스크린샷을 포함해 주세요.

## ✅ 체크리스트

- [ ] 코드가 프로젝트의 스타일 가이드를 준수합니다.
- [ ] PR 제목이 명확하고 간결하게 작성되었습니다.
- [ ] 관련 문서가 업데이트되었습니다.
- [ ] 로컬 환경에서 모든 테스트가 통과되었습니다.
- [ ] 필요한 경우 리뷰어들이 이해하기 쉽게 주석을 추가했습니다.

## 🔗 참고 자료


## ⚠️ 주의 사항

이번에는 Rx로 작성된 output코드에 탭클로저 추가했습니다.
