### PR TITLE
fix: 앨범사진을 가져올땐 사진이 제대로 나오지만 찍기로 했을땐 사진이 찌그러진 bug수정

### DIFF
--- a/PuppyTing/View/Ting/TingCollectionViewCell.swift
+++ b/PuppyTing/View/Ting/TingCollectionViewCell.swift
@@ -34,6 +34,7 @@ class TingCollectionViewCell: UICollectionViewCell {
     private let profilePic: UIImageView = {
         let imageView = UIImageView()
         imageView.image = UIImage(named: "defaultProfileImage")
+        imageView.contentMode = .scaleAspectFill
         imageView.layer.cornerRadius = 25
         imageView.layer.masksToBounds = true
         imageView.clipsToBounds = true


### PR DESCRIPTION
## 📝 개요
앨범사진을 가져올땐 사진이 제대로 나오지만 찍기로 했을땐 사진이 찌그러진 bug수정

## 📌 관련 이슈

연관된 이슈 번호를 언급해주세요:
- 관련 이슈: #이슈번호

## 🔍 변경 사항

다음과 같은 변경 사항이 있습니다:
- [ ] 변경 사항 1
- [ ] 변경 사항 2
- [ ] 변경 사항 3

## 📷 스크린샷 (선택사항)

변경 사항이 UI에 영향을 미치는 경우, 이전과 이후의 스크린샷을 포함해 주세요.

## ✅ 체크리스트

- [ ] 코드가 프로젝트의 스타일 가이드를 준수합니다.
- [ ] PR 제목이 명확하고 간결하게 작성되었습니다.
- [ ] 관련 문서가 업데이트되었습니다.
- [ ] 로컬 환경에서 모든 테스트가 통과되었습니다.
- [ ] 필요한 경우 리뷰어들이 이해하기 쉽게 주석을 추가했습니다.

## 🔗 참고 자료

PR에 참고해야 할 자료나 링크가 있다면 추가해주세요.

## ⚠️ 주의 사항

리뷰어가 중점적으로 봐야 할 사항이나, 이 PR에 포함되지 않은 추가적인 설명이 필요하다면 여기에 작성해주세요.
