### PR TITLE
[fix, feat] 차단버튼 관련 메서드 수정 및 추가

### DIFF
--- a/PuppyTing/View/Profile/ProfileCell.swift
+++ b/PuppyTing/View/Profile/ProfileCell.swift
@@ -127,8 +127,31 @@ class ProfileCell: UICollectionViewCell {
     @objc
     private func blockButtonTapped() {
         guard let userId = memberId else { return }
-        viewModel?.blockedUser(uuid: userId)
+        
+        // 차단 얼럿 띄우기 위한 코드 추가 - jgh
+        guard let parentVC = parentViewController as? ProfileViewController else { return }
+        // 차단 확인 얼럿 띄우기
+        parentVC.okAlertWithCancel(
+            title: "사용자 차단",
+            message: "사용자를 차단하시겠습니까? 차단 이후 사용자의 게시물이 보이지 않습니다.",
+            okActionTitle: "차단",
+            cancelActionTitle: "취소",
+            okActionHandler: { [weak self] (action: UIAlertAction) in
+                self?.viewModel?.blockedUser(uuid: userId)
+                parentVC.okAlert(
+                    title: "차단 완료",
+                    message: "사용자가 성공적으로 차단되었습니다.",
+                    okActionTitle: "확인",
+                    okActionHandler: nil
+                )
+            },
+            cancelActionHandler: { (action: UIAlertAction) in
+                // 취소버튼일때는 다른 작업 없어서 로그만 출력
+                print("차단 취소됨")
+            }
+        )
     }
+    
     //ksh
     @objc private func footButtonTapped() {
         guard let memberId = memberId else { return }

--- a/PuppyTing/View/Ting/DetailTingViewController.swift
+++ b/PuppyTing/View/Ting/DetailTingViewController.swift
@@ -332,22 +332,25 @@ class DetailTingViewController: UIViewController {
                 )
             }).disposed(by: disposeBag)
         
+        // 차단 버튼 수정 - jgh
         blockButton.rx.tap
             .subscribe(onNext: { [weak self] in
                 guard let userid = self?.tingFeedModels?.userid else { return }
-                self?.fireStoreDatabase.blockUser(userId: userid)
-                    .subscribe(onSuccess: { [weak self] in
-                        self?.okAlertWithCancel(
-                            title: "사용자 차단",
-                            message: "사용자를 차단하시겠습니까? 차단 이후 사용자의 게시물이 보이지 않습니다.",
-                            okActionTitle: "차단",
-                            okActionHandler: { _ in
-                                self!.okAlert(title: "차단 완료", message: "사용자가 성공적으로 차단되었습니다.")
-                            })
-                    }, onFailure: { error in
-                        print("차단 실패")
-                        self!.okAlert(title: "차단 실패", message: "사용자 차단에 실패했습니다. 다시 시도해주세요.")
-                    }).disposed(by: self!.disposeBag)
+                // 얼럿 창을 먼저 띄우기
+                self?.okAlertWithCancel(
+                    title: "사용자 차단",
+                    message: "사용자를 차단하시겠습니까? 차단 이후 사용자의 게시물이 보이지 않습니다.",
+                    okActionTitle: "차단",
+                    okActionHandler: { [weak self] _ in
+                        // 차단 버튼을 눌렀을 때 차단 로직을 실행
+                        self?.fireStoreDatabase.blockUser(userId: userid)
+                            .subscribe(onSuccess: { [weak self] in
+                                self?.okAlert(title: "차단 완료", message: "사용자가 성공적으로 차단되었습니다.")
+                            }, onFailure: { error in
+                                print("차단 실패")
+                                self?.okAlert(title: "차단 실패", message: "사용자 차단에 실패했습니다. 다시 시도해주세요.")
+                            }).disposed(by: self!.disposeBag)
+                    })
             }).disposed(by: disposeBag)
         
         reportButton.rx.tap


### PR DESCRIPTION
## 📝 개요

게시글에서 차단 눌렀을 때 차단 얼럿창에서 선택전에 차단로직이 실행됨
프로필에서 차단버튼눌렀을때 얼럿창 생성 안됨. 통일성 해침

## 📌 관련 이슈

연관된 이슈 번호를 언급해주세요:
- 관련 이슈: #119

## 🔍 변경 사항

다음과 같은 변경 사항이 있습니다:
- [x] 게시글에서 차단 눌렀을때 얼럿창에서 차단을 선택해야만 차단로직이 실행되도록 수정
- [x] 프로필에서 차단 눌렀을때 얼럿창 없었던 것을 통일성 위해 차단 얼럿 생성
- [ ] 변경 사항 3

## 📷 스크린샷 (선택사항)

변경 사항이 UI에 영향을 미치는 경우, 이전과 이후의 스크린샷을 포함해 주세요.

## ✅ 체크리스트

- [x] 코드가 프로젝트의 스타일 가이드를 준수합니다.
- [x] PR 제목이 명확하고 간결하게 작성되었습니다.
- [ ] 관련 문서가 업데이트되었습니다.
- [ ] 로컬 환경에서 모든 테스트가 통과되었습니다.
- [x] 필요한 경우 리뷰어들이 이해하기 쉽게 주석을 추가했습니다.

## 🔗 참고 자료

PR에 참고해야 할 자료나 링크가 있다면 추가해주세요.

## ⚠️ 주의 사항

차단얼럿 통일성위해서 프로필버튼에도 추가했는데 다른의견있다면 알려주십시오!
